### PR TITLE
Use filename instead of path

### DIFF
--- a/autosub.lua
+++ b/autosub.lua
@@ -12,7 +12,7 @@ end
 
 function download()
     log('Searching subtitles ...', 10)
-    table = { args = {subliminal, 'download', '-s', '-l', 'en', mp.get_property('path')} }
+    table = { args = {subliminal, 'download', '-s', '-l', 'en', mp.get_property('filename')} }
     result = utils.subprocess(table)
     if result.error == nil then
         -- Subtitles are downloaded successfully, so rescan to activate them:


### PR DESCRIPTION
I had problems with subtitles not being found for some videos, however I fixed it by passing the `filename` property to subliminal instead of `path`. Not sure why the full path of the video file would be needed anyway.