### PR TITLE
Handle video streams without duration property

### DIFF
--- a/autosub.lua
+++ b/autosub.lua
@@ -166,7 +166,12 @@ end
 
 -- Check if subtitles should be auto-downloaded:
 function autosub_allowed()
-    local duration = tonumber(mp.get_property('duration'))
+    local duration_prop = mp.get_property('duration')
+    local duration = 0
+    if duration_prop ~= nil then
+        duration = tonumber(duration_prop)
+    end
+
     local active_format = mp.get_property('file-format')
 
     if not bools.auto then


### PR DESCRIPTION
This patch should handle real-time video streams where duration
property is not set by MPV e.g. RTSP streams from live cameras.