### PR TITLE
Get full path instead of relative

### DIFF
--- a/autosub.lua
+++ b/autosub.lua
@@ -133,7 +133,7 @@ function control_downloads()
     mp.set_property('slang', languages[1][2])
     mp.msg.warn('Reactivate external subtitle files:')
     mp.commandv('rescan_external_files')
-    directory, filename = utils.split_path(mp.get_property('path'))
+    directory, filename = utils.split_path(utils.getcwd())
 
     if not autosub_allowed() then
         return


### PR DESCRIPTION
I've set up whitelist using a directory name 'subtitles_please', so that everything inside this directory will have their subtitles downloaded. This however didn't work and after debugging for a bit it turns out that the directory is relative `'.'` which of course doesn't contain the directory name.
To solve this I've used `utils.getcwd()` which returns full path.